### PR TITLE
Add reaction game and fullscreen overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <div class="col-12 text-center mb-3">
                 <h2 id="stats-heading" class="mb-3">Ваши характеристики</h2>
                 <div>Уровень: <span id="level-value">0</span> | XP: <span id="xp-value">0/100</span></div>
+                <button id="reset-btn" class="btn btn-danger btn-sm mt-2" onclick="resetStats()">Сбросить статы</button>
             </div>
             <div class="col-lg-3 col-md-6">
                 <div class="stats-card text-center">
@@ -103,13 +104,19 @@
                 <div class="game-card">
                     <h3 id="memory-title"><i class="fas fa-brain text-success"></i> Запомни последовательность</h3>
                     <p id="memory-desc">Повторите показанную цепочку символов.</p>
-                    <button class="btn btn-game btn-start" onclick="startMemoryGame()">Начать тренировку</button>
+                    <button class="btn btn-game btn-start" onclick="openMemoryGame()">Начать тренировку</button>
 
                     <div id="memory-game" class="game-area hidden">
-                        <div class="score" id="memory-sequence"></div>
-                        <input type="text" id="memory-input" class="logic-input" placeholder="...">
-                        <button class="game-button btn-check" onclick="submitMemory()">Проверить</button>
-                        <div id="memory-result" class="mt-2"></div>
+                        <div id="memory-play" class="play-screen">
+                            <button class="game-button btn-play" onclick="startMemoryGame()">Играть</button>
+                        </div>
+                        <div id="memory-content" class="game-content hidden">
+                            <div class="score" id="memory-sequence"></div>
+                            <input type="text" id="memory-input" class="logic-input" placeholder="...">
+                            <button class="game-button btn-check" onclick="submitMemory()">Проверить</button>
+                            <div id="memory-result" class="mt-2"></div>
+                        </div>
+                        <button class="game-button btn-close" onclick="closeOverlay('memory-game')">Закрыть</button>
                     </div>
                 </div>
             </div>
@@ -119,11 +126,16 @@
                 <div class="game-card">
                     <h3 id="numbercell-title"><i class="fas fa-th text-info"></i> Числовая клетка</h3>
                     <p id="numbercell-desc">Нужно быстро найти все числа, кратные 3, или все чётные.</p>
-                    <button class="btn btn-game btn-start" onclick="startNumberCellGame()">Начать тренировку</button>
+                    <button class="btn btn-game btn-start" onclick="openNumberCellGame()">Начать тренировку</button>
 
                     <div id="numbercell-game" class="game-area hidden">
-                        <div class="score" id="numbercell-task"></div>
-                        <div id="numbercell-grid" class="numbercell-grid"></div>
+                        <div id="numbercell-play" class="play-screen">
+                            <button class="game-button btn-play" onclick="startNumberCellGame()">Играть</button>
+                        </div>
+                        <div id="numbercell-content" class="game-content hidden">
+                            <div class="score" id="numbercell-task"></div>
+                            <div id="numbercell-grid" class="numbercell-grid"></div>
+                        </div>
                         <button class="game-button btn-close" onclick="closeOverlay('numbercell-game')">Закрыть</button>
                     </div>
                 </div>
@@ -135,20 +147,45 @@
                 <div class="game-card">
                     <h3 id="sequence-title"><i class="fas fa-puzzle-piece text-danger"></i> Числовая последовательность</h3>
                     <p id="sequence-desc">Найдите закономерность и продолжите последовательность!</p>
-                    <button class="btn btn-game btn-start" onclick="startLogicGame()">Начать тренировку</button>
+                    <button class="btn btn-game btn-start" onclick="openLogicGame()">Начать тренировку</button>
 
                     <div id="logic-game" class="game-area hidden">
-                        <div class="logic-sequence" id="logic-sequence"></div>
-                        <div class="mt-2">
-                            <input type="number" class="logic-input" id="logic-input1" placeholder="?">
-                            <input type="number" class="logic-input" id="logic-input2" placeholder="?">
-                            <button class="game-button btn-check" onclick="checkLogicAnswer()">Проверить</button>
-                            <button class="game-button btn-close" onclick="closeOverlay('logic-game')">Закрыть</button>
+                        <div id="logic-play" class="play-screen">
+                            <button class="game-button btn-play" onclick="startLogicGame()">Играть</button>
                         </div>
+                        <div id="logic-content" class="game-content hidden">
+                            <div class="logic-sequence" id="logic-sequence"></div>
+                            <div class="mt-2">
+                                <input type="number" class="logic-input" id="logic-input1" placeholder="?">
+                                <input type="number" class="logic-input" id="logic-input2" placeholder="?">
+                                <button class="game-button btn-check" onclick="checkLogicAnswer()">Проверить</button>
+                            </div>
+                    </div>
+                    <button class="game-button btn-close" onclick="closeOverlay('logic-game')">Закрыть</button>
+                </div>
+            </div>
+
+            <!-- Тест реакции -->
+            <div class="col-lg-6 col-md-12">
+                <div class="game-card">
+                    <h3 id="reaction-title"><i class="fas fa-bolt text-warning"></i> Тест реакции</h3>
+                    <p id="reaction-desc">Нажмите, когда увидите сигнал!</p>
+                    <button class="btn btn-game btn-start" onclick="openReactionGame()">Начать тренировку</button>
+
+                    <div id="reaction-game" class="game-area hidden">
+                        <div id="reaction-play" class="play-screen">
+                            <button class="game-button btn-play" onclick="startReactionGame()">Играть</button>
+                        </div>
+                        <div id="reaction-content" class="game-content hidden">
+                            <div id="reaction-message" class="score"></div>
+                            <button id="reaction-click" class="game-button hidden" onclick="finishReactionGame()">Жми!</button>
+                        </div>
+                        <button class="game-button btn-close" onclick="closeOverlay('reaction-game')">Закрыть</button>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <div id="level-modal" class="modal hidden">

--- a/script.js
+++ b/script.js
@@ -33,7 +33,12 @@ const translations = {
         sequence_title: 'Числовая последовательность',
         sequence_desc: 'Найдите закономерность и продолжите последовательность!',
         numbercell_title: 'Числовая клетка',
-        numbercell_desc: 'Нужно быстро найти все числа, кратные 3, или все чётные.'
+        numbercell_desc: 'Нужно быстро найти все числа, кратные 3, или все чётные.',
+        reaction_title: 'Тест реакции',
+        reaction_desc: 'Нажмите, когда увидите сигнал!',
+        click_now: 'Жми!',
+        reset_button: 'Сбросить статы',
+        reset_confirm: 'Вы уверены?'
     },
     en: {
         find_evens: 'Find all even numbers',
@@ -56,7 +61,12 @@ const translations = {
         sequence_title: 'Number Sequence',
         sequence_desc: 'Find the pattern and continue!',
         numbercell_title: 'Number Cell',
-        numbercell_desc: 'Quickly find all numbers divisible by 3 or all even ones.'
+        numbercell_desc: 'Quickly find all numbers divisible by 3 or all even ones.',
+        reaction_title: 'Reaction Test',
+        reaction_desc: 'Press when you see the signal!',
+        click_now: 'Click!',
+        reset_button: 'Reset stats',
+        reset_confirm: 'Are you sure?'
     }
 };
 
@@ -80,6 +90,14 @@ function save() {
 function load() {
     const saved = localStorage.getItem(STORAGE_KEY);
     return saved ? { ...DEFAULT_STATE, ...JSON.parse(saved) } : { ...DEFAULT_STATE };
+}
+
+function resetStats() {
+    if (confirm(translations[lang].reset_confirm)) {
+        state = { ...DEFAULT_STATE };
+        save();
+        updateUI();
+    }
 }
 
 function updateDifficulty() {
@@ -161,6 +179,9 @@ function applyTranslations() {
     document.getElementById('sequence-desc').textContent = translations[lang].sequence_desc;
     document.getElementById('numbercell-title').innerHTML = `<i class="fas fa-th text-info"></i> ${translations[lang].numbercell_title}`;
     document.getElementById('numbercell-desc').textContent = translations[lang].numbercell_desc;
+    document.getElementById('reaction-title').innerHTML = `<i class="fas fa-bolt text-warning"></i> ${translations[lang].reaction_title}`;
+    document.getElementById('reaction-desc').textContent = translations[lang].reaction_desc;
+    document.getElementById('reset-btn').textContent = translations[lang].reset_button;
     document.querySelectorAll('.btn-start').forEach(btn => btn.textContent = translations[lang].start_button);
     document.querySelectorAll('.btn-check').forEach(btn => btn.textContent = translations[lang].check_button);
     document.querySelectorAll('.btn-close').forEach(btn => btn.textContent = translations[lang].close_button);
@@ -170,11 +191,20 @@ function applyTranslations() {
 // ---------------- Мини-игра 2. Запомни последовательность ----------------
 const memoryGame = { sequence: [], deadline: 0, timeout: null };
 
+function openMemoryGame() {
+    openOverlay('memory-game');
+    clearTimeout(memoryGame.timeout);
+    document.getElementById('memory-play').classList.remove('hidden');
+    document.getElementById('memory-content').classList.add('hidden');
+    document.getElementById('memory-result').textContent = '';
+}
+
 function startMemoryGame() {
     generateMemorySequence();
     document.getElementById('memory-input').value = '';
     document.getElementById('memory-result').textContent = '';
-    openOverlay('memory-game');
+    document.getElementById('memory-play').classList.add('hidden');
+    document.getElementById('memory-content').classList.remove('hidden');
     displayMemorySequence();
 }
 
@@ -216,8 +246,15 @@ function submitMemory() {
 // ---------------- Мини-игра 3. Числовая последовательность ----------------
 const logicGame = { expected: [] };
 
-function startLogicGame() {
+function openLogicGame() {
     openOverlay('logic-game');
+    document.getElementById('logic-play').classList.remove('hidden');
+    document.getElementById('logic-content').classList.add('hidden');
+}
+
+function startLogicGame() {
+    document.getElementById('logic-play').classList.add('hidden');
+    document.getElementById('logic-content').classList.remove('hidden');
     newLogicTask();
 }
 
@@ -262,6 +299,12 @@ function checkLogicAnswer() {
 // ---------------- Мини-игра. Числовая клетка ----------------
 const numberCellGame = { target: 'even', remaining: 0 };
 
+function openNumberCellGame() {
+    openOverlay('numbercell-game');
+    document.getElementById('numbercell-play').classList.remove('hidden');
+    document.getElementById('numbercell-content').classList.add('hidden');
+}
+
 function startNumberCellGame() {
     const size = Math.random() < 0.5 ? 3 : 4;
     numberCellGame.target = Math.random() < 0.5 ? 'even' : 'mult3';
@@ -283,7 +326,8 @@ function startNumberCellGame() {
     document.getElementById('numbercell-task').textContent = numberCellGame.target === 'even'
         ? translations[lang].find_evens
         : translations[lang].find_mult3;
-    openOverlay('numbercell-game');
+    document.getElementById('numbercell-play').classList.add('hidden');
+    document.getElementById('numbercell-content').classList.remove('hidden');
 }
 
 function handleNumberCellClick(e) {
@@ -300,5 +344,41 @@ function handleNumberCellClick(e) {
     } else {
         el.classList.add('wrong');
     }
+}
+
+// ---------------- Мини-игра. Тест реакции ----------------
+const reactionGame = { timeout: null, start: 0 };
+
+function openReactionGame() {
+    openOverlay('reaction-game');
+    clearTimeout(reactionGame.timeout);
+    document.getElementById('reaction-play').classList.remove('hidden');
+    document.getElementById('reaction-content').classList.add('hidden');
+    document.getElementById('reaction-click').classList.add('hidden');
+    document.getElementById('reaction-message').textContent = '';
+}
+
+function startReactionGame() {
+    document.getElementById('reaction-play').classList.add('hidden');
+    document.getElementById('reaction-content').classList.remove('hidden');
+    document.getElementById('reaction-message').textContent = '...';
+    reactionGame.timeout = setTimeout(() => {
+        document.getElementById('reaction-message').textContent = translations[lang].click_now || 'Жми!';
+        document.getElementById('reaction-click').classList.remove('hidden');
+        reactionGame.start = Date.now();
+    }, 1000 + Math.random() * 2000);
+}
+
+function finishReactionGame() {
+    const t = Date.now() - reactionGame.start;
+    document.getElementById('reaction-click').classList.add('hidden');
+    if (t < 500) {
+        incrementStat('reaction');
+        addXp(10);
+        document.getElementById('reaction-message').textContent = `Отлично! ${t}мс`;
+    } else {
+        document.getElementById('reaction-message').textContent = `Медленно: ${t}мс`;
+    }
+    setTimeout(() => closeOverlay('reaction-game'), 1500);
 }
 

--- a/style.css
+++ b/style.css
@@ -318,17 +318,29 @@
 
 .game-area.overlay {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    max-width: 400px;
-    width: 90%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    transform: none;
     z-index: 999;
+    overflow: auto;
 }
 
 .numbercell-grid {
     display: grid;
     gap: 10px;
+}
+
+.play-screen {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
 }
 
 .number-cell {


### PR DESCRIPTION
## Summary
- implement fullscreen overlay mode for games
- add introductory "play" screen before each game
- create a new reaction test mini game
- keep stats persistent in localStorage and add reset button
- localise new UI strings

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6874dd99a8b08330ab18a2d7172114f7